### PR TITLE
Fix compatibility with golang.org/x/net/context.

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"errors"
+	"golang.org/x/net/context"
 )
 
-var Canceled = errors.New("canceled")
+var Canceled = context.Canceled
 
-func Parallel(cancel chan struct{}, fns ...func() error) error {
+func Parallel(done <-chan struct{}, cancel context.CancelFunc, fns ...func() error) error {
 	errs := make(chan error)
 	for _, fn := range fns {
 		thisFn := fn
@@ -19,10 +19,12 @@ func Parallel(cancel chan struct{}, fns ...func() error) error {
 		select {
 		case e := <-errs:
 			if e != nil {
-				close(cancel)
+				if cancel != nil {
+					cancel()
+				}
 				return e
 			}
-		case <-cancel:
+		case <-done:
 			return Canceled
 		}
 	}

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -6,24 +6,44 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 var errExpected error = errors.New("no good, sorry")
 
 func TestSimple(t *testing.T) {
-	err := Parallel(nil, sleep, sleep)
+	err := Parallel(nil, nil, sleep, sleep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestWithContextCancel(t *testing.T) {
-	bail := make(chan struct{})
+func TestWithChannelCancel(t *testing.T) {
+	done := make(chan struct{})
+	cancel := func() { close(done) }
 
-	err := Parallel(bail,
+	err := Parallel(done, cancel,
 		func() error {
 			time.Sleep(100 * time.Millisecond)
-			close(bail)
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+			return errors.New("shouldn't get here")
+		},
+	)
+
+	if err != Canceled {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWithContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	err := Parallel(ctx.Done(), cancel,
+		func() error {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
 			time.Sleep(100 * time.Millisecond)
 			return errors.New("shouldn't get here")
 		},


### PR DESCRIPTION
Context.Done() returns a receive-only channel, which currently can't be passed
to Parallel.  This change makes Parallel take a receive-only "done" channel and
a separate cancellation function.

Add a test to make sure it really works with Context.